### PR TITLE
adding default UTF-8 string encoding so grep can be easily used

### DIFF
--- a/cat_herder.py
+++ b/cat_herder.py
@@ -12,6 +12,7 @@ Requires:
 STARTUP_SCRIPT_TEMPLATE = """#!/bin/bash
 java -Xmx2G -XX:MaxPermSize=256M -jar {fn} nogui"""
 
+import sys
 import os
 import json
 from operator import itemgetter
@@ -131,4 +132,6 @@ def main(operation, pack_name, pack_version, install_folder, cache_folder, share
             mp.install_server()
 
 if __name__ == '__main__':
+    reload(sys)
+    sys.setdefaultencoding('utf-8')
     plac.call(main)


### PR DESCRIPTION
I found that the output from this python script couldn't be piped into grep for easy searching  when list_packs option was used.  This fixes that.
